### PR TITLE
fix: Restore missing margin-block in CodeBlock

### DIFF
--- a/app/_comps/code-snippet/_index.module.scss
+++ b/app/_comps/code-snippet/_index.module.scss
@@ -49,6 +49,7 @@
 .codeBlock {
     position: relative;
     padding: 1rch;
+    margin-block: 1.5rem;
     border: 1px solid var(--color-silver);
     border-radius: var(--radius-sm);
     outline: none;


### PR DESCRIPTION
Refer to #9 